### PR TITLE
Speed up org-kanban//move by not updating table every time

### DIFF
--- a/org-kanban.el
+++ b/org-kanban.el
@@ -347,33 +347,43 @@ Return file and marker."
             (name (org-no-properties (match-string 1))))
       (append (list :name name) (read (concat "(" (match-string 3) ")"))))))
 
+(defun org-kanban//move-table-entry (direction)
+  "Move the cell/entry in kanban table in direction DIRECTION."
+  (org-narrow-to-element)
+  ;; goes to the element in the row, assume we are anywhere on the line
+  (or (search-forward "[[" nil t)
+    (search-backward "[["))
+  (unwind-protect
+    (org-table-move-column (if (eq 'left direction) 't nil))
+    (widen)
+    (org-table-align)))
+
+(defun org-kanban//get-table-todo ()
+  "Return todo state in given column in kanban table."
+  (save-excursion
+    (let* ((cur-col (org-table-current-column)))
+      (org-table-goto-line 1)
+      (org-table-goto-column cur-col)
+      (-> (org-table-get-field)
+        (org-no-properties)
+        (s-trim)))))
+
 (defun org-kanban//move (direction)
   "Move the todo entry in the current line of the kanban table to the next state in direction DIRECTION."
-  (let* ((range (plist-get (org-kanban//get-dynamic-block-parameters) :range)))
-    (save-window-excursion
-      (if (-contains? (list 'left 'right) direction)
-        (let* (
-                (file-and-marker (org-kanban//find))
-                (line (line-number-at-pos))
-                (file (nth 0 file-and-marker))
-                (marker (nth 1 file-and-marker)))
-          (if (and file-and-marker file marker)
-            (if (save-excursion
-                  (find-file file)
-                  (goto-char marker)
-                  (let* (
-                          (current (substring-no-properties (org-get-todo-state)))
-                          (border (car (if (eq direction 'right) (reverse org-todo-keywords-1) org-todo-keywords-1)))
-                          (range-border (if (eq direction 'right) (cdr range) (car range)))
-                          (change (and (not (string-equal current border))
-                                    (not (string-equal current range-border)))))
-                    (if change (org-todo direction))
-                    change))
-              (progn
-                (org-dblock-update)
-                (goto-char 0)
-                (forward-line (1- line))
-                (goto-char (search-forward "[["))))))))))
+  (save-window-excursion
+    (if (-contains? (list 'left 'right) direction)
+      (let* (
+              (file-and-marker (org-kanban//find))
+              (file (nth 0 file-and-marker))
+              (marker (nth 1 file-and-marker)))
+        (when (and file-and-marker file marker)
+          (with-demoted-errors
+            (org-kanban//move-table-entry direction)
+            (let ((todo (org-kanban//get-table-todo)))
+              (save-excursion
+                (find-file file)
+                (goto-char marker)
+                (org-todo todo)))))))))
 
   (defun org-kanban//params-layout (params)
     "Calculate layout func based on PARAMS."


### PR DESCRIPTION
Move table cells/entries with `org-kanban//move-table-entry` directly in kanban
board and set the new todo state of the entry using the tooh keyword in kanban
column where the entry is now located.

I have tested it on some of my big org files with lots of TODOs entries. Using it this way is now a much more smoother experience.