### PR TITLE
feature: Add :keywords parameter to block.

### DIFF
--- a/org-kanban.el
+++ b/org-kanban.el
@@ -196,7 +196,7 @@ This means, that the org-kanban table links are in one of several forms:
         ))
     ""))
 
-(defun org-kanban//todo-keywords (files mirrored range-fun)
+(defun org-kanban//todo-keywords (files mirrored range-fun keyword-matches)
   "Get list of org todos from FILES.  MIRRORED describes if keywords should be reversed.  RANGE-FUN filters keywords."
   (save-window-excursion
     (let* (
@@ -206,8 +206,12 @@ This means, that the org-kanban table links are in one of several forms:
                                             org-todo-keywords-1)
                                           files)))
             (filtered (-distinct (-filter (lambda (i) (funcall range-fun i list-of-keywords)) list-of-keywords)))
-            (keywords (if mirrored (reverse filtered) filtered)))
-      keywords)))
+            (keywords (if mirrored (reverse filtered) filtered))
+            (keywords* (if keyword-matches
+                           (-filter (lambda (i) (member i keyword-matches)) keywords)
+                            keywords))
+            )
+      keywords*)))
 
 (defun org-kanban//row-entries-for (todo-info todo-keywords layout)
   "Convert a kanban TODO-INFO to elements of a row for org-table.
@@ -638,7 +642,7 @@ PARAMS may contain `:mirrored`, `:match`, `:scope`, `:layout`, `:range`, `:depth
         (layout (org-kanban//params-layout params))
         (files (org-kanban//params-files params))
         (scope (org-kanban//params-scope params files))
-        (todo-keywords (org-kanban//todo-keywords files mirrored (lambda (value keywords) (org-kanban//range-fun value keywords (car range) (cdr range)))))
+        (todo-keywords (org-kanban//todo-keywords files mirrored (lambda (value keywords) (org-kanban//range-fun value keywords (car range) (cdr range))) '("TODO" "STRT" "DONE" "KILL")))
         (sort-spec-string (plist-get params :sort))
         (sort-spec (org-kanban--prepare-comparator sort-spec-string todo-keywords))
         (todo-infos (org-map-entries 'org-kanban//todo-info-extract match scope))

--- a/org-kanban.el
+++ b/org-kanban.el
@@ -630,7 +630,7 @@ the rest of the functions is used."
 ;;;###autoload
 (defun org-dblock-write:kanban (params)
   "Create the kanban dynamic block.
-PARAMS may contain `:mirrored`, `:match`, `:scope`, `:layout`, `:range`, `:depth` and `:compressed`."
+PARAMS may contain `:mirrored`, `:match`, `:scope`, `:layout`, `:range`, `:depth`, `:compressed`, and `:keywords`."
   (insert
     (let*
       (
@@ -638,11 +638,12 @@ PARAMS may contain `:mirrored`, `:match`, `:scope`, `:layout`, `:range`, `:depth
         (compressed (plist-get params :compressed))
         (match (plist-get params :match))
         (range (plist-get params :range))
+        (keywords (plist-get params :keywords))
         (depth (org-kanban--params-depth params))
         (layout (org-kanban//params-layout params))
         (files (org-kanban//params-files params))
         (scope (org-kanban//params-scope params files))
-        (todo-keywords (org-kanban//todo-keywords files mirrored (lambda (value keywords) (org-kanban//range-fun value keywords (car range) (cdr range))) '("TODO" "STRT" "DONE" "KILL")))
+        (todo-keywords (org-kanban//todo-keywords files mirrored (lambda (value keywords) (org-kanban//range-fun value keywords (car range) (cdr range))) keywords))
         (sort-spec-string (plist-get params :sort))
         (sort-spec (org-kanban--prepare-comparator sort-spec-string todo-keywords))
         (todo-infos (org-map-entries 'org-kanban//todo-info-extract match scope))


### PR DESCRIPTION
Hi,

I just started using doom-emacs and their org-mode comes chock full with TODO keywords. This made kanban's output unfriendly. Here I'm showing it match nothing just for the sake of demonstration. It's worse when the keywords have items in them.

```
#+BEGIN: kanban :mirrored nil :match "NA"
| TODO | PROJ | LOOP | STRT | WAIT | HOLD | IDEA | DONE | KILL | [ ] | [-] | [?] | [X] | OKAY | YES | NO |
|------+------+------+------+------+------+------+------+------+-----+-----+-----+-----+------+-----+----|

#+END:
```

So I added a :keywords parameter that works like this:

```
#+BEGIN: kanban :mirrored nil :match "NA" :keywords ("TODO" "STRT" "DONE" "KILL")
| TODO | STRT | DONE | KILL |
|------+------+------+------|

#+END:
```

Thank you for creating this project. I hope you find this useful.

-Shane
