### PR TITLE
Expand filenames in `:scope` like agenda files

### DIFF
--- a/org-kanban.el
+++ b/org-kanban.el
@@ -541,14 +541,13 @@ Return file and marker."
       layout))
 
 (defun org-kanban//expand-like-agenda-files (files)
-  (apply 'append
-         (mapcar (lambda (f)
-                   (let ((f (symbol-name f)))
-                     (if (file-directory-p f)
-                         (directory-files
-                          f t org-agenda-file-regexp)
-                       (list (expand-file-name f)))))
-                 files)))
+  "Expand FILES like org agenda would do it.  This will also pick up all org files in a directory."
+  (let ((file-strings (-map (lambda (f) (symbol-name f)) files)))
+    (-flatten (-map (lambda (f)
+                      (if (file-directory-p f)
+                        (directory-files f t org-agenda-file-regexp)
+                        (list (expand-file-name f))))
+        file-strings))))
 
 (defun org-kanban//params-files (params)
   "Calculate files based on PARAMS."

--- a/org-kanban.el
+++ b/org-kanban.el
@@ -542,13 +542,13 @@ Return file and marker."
 
 (defun expand-like-agenda-files (files)
   (apply 'append
-	 (mapcar (lambda (f)
-		   (let ((f (symbol-name f)))
-		     (if (file-directory-p f)
-			 (directory-files
-			  f t org-agenda-file-regexp)
-		       (list (expand-file-name f)))))
-		 files)))
+         (mapcar (lambda (f)
+                   (let ((f (symbol-name f)))
+                     (if (file-directory-p f)
+                         (directory-files
+                          f t org-agenda-file-regexp)
+                       (list (expand-file-name f)))))
+                 files)))
 
 (defun org-kanban//params-files (params)
   "Calculate files based on PARAMS."

--- a/org-kanban.el
+++ b/org-kanban.el
@@ -540,7 +540,7 @@ Return file and marker."
                       (_ (error (format "Unknown type %s" l))))))
       layout))
 
-(defun expand-like-agenda-files (files)
+(defun org-kanban//expand-like-agenda-files (files)
   (apply 'append
          (mapcar (lambda (f)
                    (let ((f (symbol-name f)))
@@ -557,7 +557,7 @@ Return file and marker."
           (files (pcase scope
                    (`nil (list buffer-file-name))
                    (`tree (list buffer-file-name))
-                   (_  (expand-like-agenda-files scope)))))
+                   (_  (org-kanban//expand-like-agenda-files scope)))))
     files))
 
 (defun org-kanban//params-scope (params files)

--- a/org-kanban.el
+++ b/org-kanban.el
@@ -540,6 +540,16 @@ Return file and marker."
                       (_ (error (format "Unknown type %s" l))))))
       layout))
 
+(defun expand-like-agenda-files (files)
+  (apply 'append
+	 (mapcar (lambda (f)
+		   (let ((f (symbol-name f)))
+		     (if (file-directory-p f)
+			 (directory-files
+			  f t org-agenda-file-regexp)
+		       (list (expand-file-name f)))))
+		 files)))
+
 (defun org-kanban//params-files (params)
   "Calculate files based on PARAMS."
   (let* (
@@ -547,7 +557,7 @@ Return file and marker."
           (files (pcase scope
                    (`nil (list buffer-file-name))
                    (`tree (list buffer-file-name))
-                   (_  (-map (lambda(file) (symbol-name file)) scope)))))
+                   (_  (expand-like-agenda-files scope)))))
     files))
 
 (defun org-kanban//params-scope (params files)


### PR DESCRIPTION
The `:scope` tag cannot contain files with multiple subdirectories because
org-kanban.el and org itself keeps state (the working directory) when
checking whether (agenda) files exists.  Since org-mode has an interface
to add agenda files resulting in the files to be added in the form of
absolute paths, this commit suggests to treat the parameters of `:scope`
in the same way.  Added benefit is that it allows you to use a directory
in the `:scope` tag which results in all org files to be added to the
kanban table.