### PR TITLE
Fix infinite loop with org-kanban/shift

### DIFF
--- a/org-kanban.el
+++ b/org-kanban.el
@@ -397,7 +397,7 @@ Return file and marker."
         (if marker
           (if (and
                 (eq (marker-position marker) required-point)
-                (eq file required-file))
+                (string-equal file required-file))
             (setq done-p t)
             (forward-line 1))
           (forward-line 1))))))


### PR DESCRIPTION
If this condition is always false due to two strings not being the same object, the search could never terminate.